### PR TITLE
Portability mods from the neuronsimulator

### DIFF
--- a/include/Random123/features/compilerfeatures.h
+++ b/include/Random123/features/compilerfeatures.h
@@ -208,16 +208,18 @@ added to each of the *features.h files, AND to examples/ut_features.cpp.
 #include "iccfeatures.h"
 #elif defined(__xlC__) || defined(__ibmxl__)
 #include "xlcfeatures.h"
+#elif defined(__PGI)
+#include "pgccfeatures.h"
 #elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
 #include "sunprofeatures.h"
 #elif defined(__OPEN64__)
 #include "open64features.h"
-#elif defined(__clang__)
+#elif defined(__clang__) || defined(__bgclang__)
 #include "clangfeatures.h"
+#elif defined(__FCC_VERSION) || defined(__FUJITSU)
+#include "fujitsufeatures.h"
 #elif defined(__GNUC__)
 #include "gccfeatures.h"
-#elif defined(__PGI)
-#include "pgccfeatures.h"
 #elif defined(_MSC_FULL_VER)
 #include "msvcfeatures.h"
 #else

--- a/include/Random123/features/fujitsufeatures.h
+++ b/include/Random123/features/fujitsufeatures.h
@@ -1,0 +1,86 @@
+/*
+Note: Minimum/Initial version derived from openclfeatures.h to work
+with fujitsu compiler (_FCC).
+*/
+
+#ifndef __fujitsufeatures_dot_hpp
+#define __fujitsufeatures_dot_hpp
+
+#ifndef R123_STATIC_INLINE
+#define R123_STATIC_INLINE static __inline
+#endif
+
+#ifndef R123_FORCE_INLINE
+#define R123_FORCE_INLINE(decl) decl
+#endif
+
+#ifndef R123_CUDA_DEVICE
+#define R123_CUDA_DEVICE
+#endif
+
+#ifndef R123_ASSERT
+#include <assert.h>
+#define R123_ASSERT(x) assert(x)
+#endif
+
+#ifndef R123_BUILTIN_EXPECT
+#define R123_BUILTIN_EXPECT(expr,likely) expr
+#endif
+
+#ifndef R123_USE_WMMINTRIN_H
+#define R123_USE_WMMINTRIN_H 0
+#endif
+
+#ifndef R123_USE_INTRIN_H
+#define R123_USE_INTRIN_H 0
+#endif
+
+#ifndef R123_USE_MULHILO32_ASM
+#define R123_USE_MULHILO32_ASM 0
+#endif
+
+#ifndef R123_USE_MULHILO64_ASM
+#define R123_USE_MULHILO64_ASM 0
+#endif
+
+#ifndef R123_USE_MULHILO64_MSVC_INTRIN
+#define R123_USE_MULHILO64_MSVC_INTRIN 0
+#endif
+
+#ifndef R123_USE_MULHILO64_CUDA_INTRIN
+#define R123_USE_MULHILO64_CUDA_INTRIN 0
+#endif
+
+#ifndef R123_USE_MULHILO64_OPENCL_INTRIN
+#define R123_USE_MULHILO64_OPENCL_INTRIN 0
+#endif
+
+#ifndef R123_USE_MULHILO64_MULHI_INTRIN
+#if (defined(__powerpc64__))
+#define R123_USE_MULHILO64_MULHI_INTRIN 1
+#else
+#define R123_USE_MULHILO64_MULHI_INTRIN 0
+#endif
+#endif
+
+#ifndef R123_MULHILO64_MULHI_INTRIN
+#define R123_MULHILO64_MULHI_INTRIN __mulhdu
+#endif
+
+#ifndef R123_USE_MULHILO32_MULHI_INTRIN
+#define R123_USE_MULHILO32_MULHI_INTRIN 0
+#endif
+
+#ifndef R123_MULHILO32_MULHI_INTRIN
+#define R123_MULHILO32_MULHI_INTRIN __mulhwu
+#endif
+
+#ifndef __STDC_CONSTANT_MACROS
+#define __STDC_CONSTANT_MACROS
+#endif
+#include <stdint.h>
+#ifndef UINT64_C
+#error UINT64_C not defined.  You must define __STDC_CONSTANT_MACROS before you #include <stdint.h>
+#endif
+
+#endif

--- a/include/Random123/features/pgccfeatures.h
+++ b/include/Random123/features/pgccfeatures.h
@@ -46,7 +46,7 @@ so as not to confuse it with the version available from LANL.
 #ifndef __pgccfeatures_dot_hpp
 #define __pgccfeatures_dot_hpp
 
-#if !defined(__x86_64__) && !defined(__i386__)
+#if !defined(__x86_64__) && !defined(__i386__) && !defined(__powerpc64__)
 #  error "This code has only been tested on x86 platforms."
 #include <including_a_nonexistent_file_will_stop_some_compilers_from_continuing_with_a_hopeless_task>
 { /* maybe an unbalanced brace will terminate the compilation */


### PR DESCRIPTION
https://github.com/neuronsimulator/nrn contains a derived copy of
Random123-1.08 with modifications.  Most of the mods are already in
the current version, but a few look like they'll improve portability
with the PGI and Fujitsu compilers.  Untested, but it seems worth the
risk.