### PR TITLE
define NVIDIA specific device math library functions

### DIFF
--- a/include/Random123/boxmuller.hpp
+++ b/include/Random123/boxmuller.hpp
@@ -93,7 +93,7 @@ R123_CUDA_DEVICE R123_STATIC_INLINE void sincos(double x, double *s, double *c) 
 }
 #endif /* sincos is not in the math library */
 
-#if !defined(CUDART_VERSION) || CUDART_VERSION < 5000 /* enabled if sincospi and sincospif are not in math lib */
+#if !defined(__CUDACC__) || !defined(CUDART_VERSION) || (CUDART_VERSION < 5000) /* enabled if sincospi and sincospif are not in math lib */
 
 R123_CUDA_DEVICE R123_STATIC_INLINE void sincospif(float x, float *s, float *c){
     const float PIf = 3.1415926535897932f;


### PR DESCRIPTION
these are needed when compiling for the host since NVIDIA only defines them for the device. the specific use case we have is that our library makes use of cuda, but is currently using random123 on the host, and these functions end up not defined. 

we have compile error such as:
```
In file included from /work/rblas/RandBLAS-install/include/RandBLAS/dense_op.hh:19,
                 from /work/rblas/RandBLAS-install/include/RandBLAS.hh:6,
                 from /work/rblas/RandLAPACK/src/comps/rs.cc:2:
/work/rblas/random123-install/include/Random123/boxmuller.hpp: In function ‘r123::float2 r123::boxmuller(uint32_t, uint32_t)’:
/work/rblas/random123-install/include/Random123/boxmuller.hpp:119:5: error: ‘sincospif’ was not declared in this scope; did you mean ‘sincosf’?
  119 |     sincospif(uneg11<float>(u0), &f.x, &f.y);
      |     ^~~~~~~~~
      |     sincosf
/work/rblas/random123-install/include/Random123/boxmuller.hpp: In function ‘r123::double2 r123::boxmuller(uint64_t, uint64_t)’:
/work/rblas/random123-install/include/Random123/boxmuller.hpp:134:5: error: ‘sincospi’ was not declared in this scope; did you mean ‘sincosl’?
  134 |     sincospi(uneg11<double>(u0), &f.x, &f.y);
      |     ^~~~~~~~
      |     sincosl

```
The goal of the change in this PR is to define these functions when compiling on the host and to use NVIDIA's definition when compiling for the  device. I have only explicitly tested the former.